### PR TITLE
feat(maintenance & sync): add authenticated sync button, maintenance endpoint, cron schedules and lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ yarn lint
 Application can be deployed in docker container by running
 
 ```shell
-docker-compose up --build
+docker compose up --build
 ```
 
 or
 
 ```shell
- docker-compose up
+ docker compose up
 ```
 
 #### Less

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,3 +48,9 @@ SMTP_USER=user
 SMTP_PASSWORD=password
 
 EMAIL_SENDER=no-reply@example.com
+
+# Cron Schedules (uses standard cron syntax)
+# Default for both is '0 3 * * 0' (every Sunday at 3:00 AM)
+# Every day at midnight would be '0 0 * * *'
+REMOVE_EXPIRED_DRAFTS_SCHEDULE=0 3 * * 0
+SYNC_GITBOOK_REQUIREMENTS_SCHEDULE=0 3 * * 0

--- a/backend/__tests__/gitBookApi.test.ts
+++ b/backend/__tests__/gitBookApi.test.ts
@@ -37,7 +37,11 @@ describe('GitBook API', () => {
 
             // Process the data
             const contentManager = new GitBookPageContentManager();
-            const result = contentManager.extractFunctionalRequirements(testData);
+            const result = contentManager.extractFunctionalRequirements(
+                testData,
+                'functional-requirements',
+                'test-bb-key'
+            );
             if ('error' in result) {
                 throw result.error;
             }
@@ -62,7 +66,11 @@ describe('GitBook API', () => {
           
             // Process the data
             const contentManager = new GitBookPageContentManager();
-            const result = contentManager.extractFunctionalRequirements(testData);
+            const result = contentManager.extractFunctionalRequirements(
+                testData,
+                'functional-requirements',
+                'some_key'
+            );
             if ('error' in result) {
                 throw result.error;
             }
@@ -105,7 +113,12 @@ describe('GitBook API', () => {
 
             // Process the data
             const contentManager = new GitBookPageContentManager();
-            const result = contentManager.extractCrossCuttingRequirements(testData, null);
+            const result = contentManager.extractCrossCuttingRequirements(
+                testData,
+                null,
+                'cross-cutting-requirements',
+                'test-bb-key'
+            );
             if ('error' in result) {
                 throw result.error;
             }
@@ -130,7 +143,12 @@ describe('GitBook API', () => {
           
             // Process the data
             const contentManager = new GitBookPageContentManager();
-            const result = contentManager.extractCrossCuttingRequirements(testData, null);
+            const result = contentManager.extractCrossCuttingRequirements(
+                testData,
+                null,
+                'cross-cutting-requirements',
+                'test-bb-key'
+            );
             if ('error' in result) {
                 throw result.error;
             }

--- a/backend/__tests__/maintenanceRoutes.test.ts
+++ b/backend/__tests__/maintenanceRoutes.test.ts
@@ -1,0 +1,60 @@
+/// <reference types="mocha" />
+import chai, { expect } from 'chai';
+import request from 'supertest';
+import sinon from 'sinon';
+import jwt from 'jsonwebtoken';
+import app from '../server';
+import * as removeExpired from '../src/cronJobs/removeExpiredDrafts';
+import * as syncGitBook from '../src/cronJobs/syncGitBookBBRequirements';
+import * as lock from '../src/shared/maintenanceLock';
+import { appConfig } from '../src/config';
+
+describe('Maintenance API', () => {
+  let token: string;
+
+  before(() => {
+    // Create a valid GitHub token
+    token = jwt.sign({ user: 'test' }, appConfig.gitHub.jwtSecret);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should reject unauthorized requests', async () => {
+    const res = await request(app).post('/maintenance/sync');
+    expect(res.status).to.equal(401);
+    expect(res.body).to.have.property('message', 'User not authorized');
+  });
+
+  it('should execute maintenance tasks when authenticated', async () => {
+    const removeStub = sinon.stub(removeExpired, 'removeSensitiveDataFromExpiredDrafts').resolves();
+    const syncStub = sinon.stub(syncGitBook, 'default').resolves();
+
+    const res = await request(app)
+      .post('/maintenance/sync')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(removeStub.calledOnce).to.be.true;
+    expect(syncStub.calledOnce).to.be.true;
+    expect(res.status).to.equal(200);
+    expect(res.body).to.deep.equal({
+      success: true,
+      message: 'Maintenance tasks completed successfully'
+    });
+  });
+
+  it('should prevent concurrent executions', async () => {
+    sinon.stub(lock, 'acquireLock').returns(false);
+
+    const res = await request(app)
+      .post('/maintenance/sync')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).to.equal(409);
+    expect(res.body).to.deep.equal({
+      success: false,
+      message: 'Maintenance is already in progress'
+    });
+  });
+});

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -20,6 +20,7 @@ import buildReportRoutes from './src/routes/record';
 import buildComplianceRoutes from "./src/routes/compliance";
 import { startCronJobs } from "./src/cronJobs";
 import buildAuthRoutes from "./src/routes/auth";
+import maintenanceRoutes from "./src/routes/maintenanceRoutes";
 import multer from 'multer';
 
 const port: number = parseInt(process.env.PORT as string, 10) || 5000;
@@ -35,6 +36,7 @@ app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 app.use(buildReportRoutes(reportController(reportRepository, mongoReportRepository)));
 app.use(buildComplianceRoutes(complianceController(complianceRepository, mongoComplianceRepository)));
 app.use(buildAuthRoutes());
+app.use('/maintenance', maintenanceRoutes);
 
 app.use((err: any, _: express.Request, res: express.Response, next: express.NextFunction) => {
     if (err instanceof multer.MulterError) {

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -66,8 +66,8 @@ const appConfig: AppConfig = {
     : 30 * 24 * 60 * 60 * 1000,
   frontendHost: process.env.FE_HOST,
   cron: {
-    removeExpiredDraftsSchedule: '0 3 * * 0', // Run every Sunday at 3:00 AM
-    syncGitBookRequirementsSchedule: '0 3 * * 0', // Run every Sunday at 3:00 AM
+    removeExpiredDraftsSchedule: process.env.REMOVE_EXPIRED_DRAFTS_SCHEDULE || '0 3 * * 0', // Run every Sunday at 3:00 AM
+    syncGitBookRequirementsSchedule: process.env.SYNC_GITBOOK_REQUIREMENTS_SCHEDULE || '0 3 * * 0', // Run every Sunday at 3:00 AM
   },
   enableJiraIntegration: process.env.ENABLE_JIRA_INTEGRATION ? process.env.ENABLE_JIRA_INTEGRATION === 'true' : false,
   gitBook: {

--- a/backend/src/cronJobs/index.ts
+++ b/backend/src/cronJobs/index.ts
@@ -2,23 +2,38 @@ import { schedule } from 'node-cron';
 import { removeSensitiveDataFromExpiredDrafts } from './removeExpiredDrafts';
 import { appConfig } from '../config';
 import syncGitBookBBRequirements from './syncGitBookBBRequirements';
+import { acquireLock, releaseLock } from '../shared/maintenanceLock';
 
 export const startCronJobs = (): void => {
   schedule(appConfig.cron.removeExpiredDraftsSchedule, async () => {
+    if (!acquireLock()) {
+      console.log('Maintenance is already running, skipping remove expired drafts job');
+      return;
+    }
+
     console.log('Running a job to remove sensitive data from expired drafts');
     try {
       await removeSensitiveDataFromExpiredDrafts();
     } catch (error) {
       console.error('An error occurred', error);
+    } finally {
+      releaseLock();
     }
   });
 
   schedule(appConfig.cron.syncGitBookRequirementsSchedule, async () => {
+    if (!acquireLock()) {
+      console.log('Maintenance is already running, skipping sync GitBook requirements job');
+      return;
+    }
+
     console.log('Running job to sync GitBook requirements');
     try {
       await syncGitBookBBRequirements();
     } catch (error) {
       console.error('An error occurred in syncGitBookRequirements', error);
+    } finally {
+      releaseLock();
     }
   });
 };

--- a/backend/src/routes/maintenanceRoutes.ts
+++ b/backend/src/routes/maintenanceRoutes.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { removeSensitiveDataFromExpiredDrafts } from '../cronJobs/removeExpiredDrafts';
+import syncGitBookBBRequirements from '../cronJobs/syncGitBookBBRequirements';
+import verifyGithubToken from '../middlewares/requiredAuthMiddleware';
+import { acquireLock, releaseLock } from '../shared/maintenanceLock';
+
+const router = Router();
+
+router.post('/sync', verifyGithubToken, async (_req, res) => {
+    if (!acquireLock()) {
+        return res.status(409).json({ 
+            success: false, 
+            message: 'Maintenance is already in progress' 
+        });
+    }
+
+    try {
+        // Run both maintenance tasks sequentially
+        await removeSensitiveDataFromExpiredDrafts();
+        await syncGitBookBBRequirements();
+        
+        return res.json({ 
+            success: true, 
+            message: 'Maintenance tasks completed successfully' 
+        });
+    } catch (error) {
+        console.error('Error during maintenance:', error);
+        return res.status(500).json({ 
+            success: false, 
+            message: 'Error during maintenance tasks',
+            error: error instanceof Error ? error.message : String(error)
+        });
+    } finally {
+        releaseLock();
+    }
+});
+
+export default router;

--- a/backend/src/shared/maintenanceLock.ts
+++ b/backend/src/shared/maintenanceLock.ts
@@ -1,0 +1,14 @@
+// Shared state for maintenance tasks
+export let isMaintenanceRunning = false;
+
+export const acquireLock = (): boolean => {
+    if (isMaintenanceRunning) {
+        return false;
+    }
+    isMaintenanceRunning = true;
+    return true;
+};
+
+export const releaseLock = (): void => {
+    isMaintenanceRunning = false;
+};

--- a/frontend/components/header/Header.less
+++ b/frontend/components/header/Header.less
@@ -53,6 +53,19 @@
   color: inherit;
 }
 
+.header-icon.syncing {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .action-buttons {
   display: flex;
   margin-left: auto;

--- a/frontend/service/serviceAPI.ts
+++ b/frontend/service/serviceAPI.ts
@@ -693,3 +693,25 @@ export const fetchFileDetails = async (file: string) => {
     return undefined;
   }
 };
+
+export const syncGitBookBBRequirements = async () => {
+  const accessToken = sessionStorage.getItem('accessToken');
+
+  return await fetch(`${baseUrl}/maintenance/sync`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+    },
+  })
+    .then((response) => {
+      if (!response.ok) {
+        const errorMessage = response.statusText || 'An error occurred while syncing building block requirements.';
+
+        const error: FormErrorResponseType = { status: response.status, name: 'CustomError', message: errorMessage };
+        throw error;
+      }
+
+      return response.json();
+    });
+}

--- a/frontend/translations/en.ts
+++ b/frontend/translations/en.ts
@@ -38,6 +38,7 @@ export const en = {
     'API Compliance & Requirement Specification Compliance',
   'app.login.label': 'Log In',
   'app.logout.label': 'Log Out',
+  'app.sync.label': 'Sync',
   'app.tests_passed.label': 'Tests Passed',
   'app.tests_failed.label': 'Tests Failed',
   'app.save.label': 'Save',


### PR DESCRIPTION
This PR brings together the last three commits to fully implement a secure, configurable maintenance workflow—both on the backend and in the frontend UI. Key changes include:

Environment & Configuration

Introduced two new env variables in [.env.example](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
REMOVE_EXPIRED_DRAFTS_SCHEDULE
SYNC_GITBOOK_REQUIREMENTS_SCHEDULE
Updated appConfig.cron in [index.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to read these values (with defaults).
Maintenance Lock & Cron Jobs

Created a shared lock ([acquireLock](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[releaseLock](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to prevent concurrent maintenance tasks.
Wired up node-cron jobs in [index.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to run on the configured schedules, guarded by the lock.
Authenticated Maintenance API

Added a new Express route POST /maintenance/sync in [maintenanceRoutes.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Secured with [verifyGithubToken](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) middleware to ensure only authenticated GitHub users can trigger maintenance.
Runs removal of expired drafts and GitBook sync sequentially, returns clear success/error JSON, and respects the shared lock.
Covered with full tests ([maintenanceRoutes.test.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) for unauthorized access, happy path, and lock contention.
Frontend “Sync” Button

Refactored the header’s sync button in [Header.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to call the /maintenance/sync API instead of redirecting.
Sends the stored GitHub access token as a Bearer header.
Shows loading state (disabled button + spinning icon) to prevent duplicate clicks and improve UX.
Added corresponding CSS animation in [Header.less](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Testing & Validation

✅ Backend tests for maintenance routes pass.
✅ Manual verification of cron schedules (via logs).
✅ Frontend “Sync” button now triggers the API, uses auth headers, and reflects loading state.